### PR TITLE
FIX: Use owner in extension context.

### DIFF
--- a/src/Extension/BaseElementExtension.php
+++ b/src/Extension/BaseElementExtension.php
@@ -168,10 +168,10 @@ class BaseElementExtension extends DataExtension
                 $wasPublished = false;
             }
             if ($firstVirtual) {
-                $origParentID = $this->ParentID;
-                $origSort = $this->Sort;
+                $origParentID = $this->owner->ParentID;
+                $origSort = $this->owner->Sort;
 
-                $clone = $this->duplicate(false);
+                $clone = $this->owner->duplicate(false);
 
                 // set clones values to first virtual's values
                 $clone->ParentID = $firstVirtual->ParentID;


### PR DESCRIPTION
Fix issue where extension references properties of `BaseElement` in `onBeforeDelete` hook.