### PR TITLE
Changes so that elements can be moved to a different location instead of copying

### DIFF
--- a/src/Extension/BaseElementExtension.php
+++ b/src/Extension/BaseElementExtension.php
@@ -35,6 +35,11 @@ class BaseElementExtension extends DataExtension
         'AvailableGlobally' => 'Boolean(1)'
     ];
 
+    /** I added this part to make all newly created elements 'AvailableGlobally' by default **/
+    private static $defaults [
+        'AvailableGlobally' => 1
+    ];
+    
     /**
      * @var array $has_many
      */

--- a/src/Extension/ElementalEditorExtension.php
+++ b/src/Extension/ElementalEditorExtension.php
@@ -15,10 +15,13 @@ class ElementalEditorExtension extends DataExtension
     {
         $searchList = BaseElement::get()->filter('AvailableGlobally', 1);
 
+        /** I added "true" in line 24 below so an element can be unlinked from its current location instead of deleted
+        * so it is available to be re-linked in a new location **/
+        
         $gridField->getConfig()
             ->removeComponentsByType(GridFieldDeleteAction::class)
             ->addComponent($autocomplete = new ElementalGridFieldAddExistingAutocompleter('toolbar-header-right'))
-            ->addComponent(new ElementalGridFieldDeleteAction());
+            ->addComponent(new ElementalGridFieldDeleteAction(true));
 
         $autocomplete->setSearchList($searchList);
         $autocomplete->setResultsFormat('($ID) $Title');


### PR DESCRIPTION
I made 2 small changes:
1. made the element unlink instead of delete (to allow it to be re-linked in a new location)
2. made all new elements globally available by default so they cant be accidentally lost if they get unlinked without that box (hidden on secondary tab) being ticked

new usage workflow:
1. unlink element where it is now
2. use the link existing search box to add it to a new location

caveat: you have to do the unlink step first because it won't allow the original to be unlinked if it gets copied first

I made these changes because that is the behaviour I was expecting of the module - please see my issue #445 on the silverstripe-elemental module (https://github.com/dnadesign/silverstripe-elemental/issues/445)
It is also raised in issue #10 on this module.
Additionally, there is discussion about it in the slack archive website, channel= content-blocks, question asked at 2018-08-08 16:28:25 then response thread started at 2018-08-08 17:14:08 (sorry, can't find permalink to messages)

Please let me know if I need to make any modifications or do anything extra (my first pull request for code!!)
Thanks :-)