### PR TITLE
Update BaseElementExtension.php to add $defaults

### DIFF
--- a/src/Extension/BaseElementExtension.php
+++ b/src/Extension/BaseElementExtension.php
@@ -34,6 +34,11 @@ class BaseElementExtension extends DataExtension
     private static $db = [
         'AvailableGlobally' => 'Boolean(1)'
     ];
+    
+    /* make created elements available globally by default */
+    private static $defaults = [
+        'AvailableGlobally' => 1
+    ];
 
     /**
      * @var array $has_many


### PR DESCRIPTION
Update BaseElementExtension.php to add $defaults = ['AvailableGlobally' => 1]; as the existing method of setting 1 as default in the $db doesn't work

As requested by @robbieaverill in issue #20 