### PR TITLE
Open virtual link in a new window

### DIFF
--- a/src/Model/ElementVirtual.php
+++ b/src/Model/ElementVirtual.php
@@ -60,9 +60,10 @@ class ElementVirtual extends BaseElement
     public function getCMSFields()
     {
         $message = sprintf(
-            '<p>%s</p><p><a href="%2$s">Click here to edit the original</a></p>',
+            '<p>%s</p><p><a href="%2$s" target="_blank" rel="noopener noreferrer">%s</a></p>',
             _t(__CLASS__ . '.VirtualDescription', 'This is a virtual copy of an element.'),
-            $this->LinkedElement()->getEditLink()
+            $this->LinkedElement()->getEditLink(),
+            _t(__CLASS__ . '.VirtualLinkTitle', 'Click here to edit the original')
         );
 
         $fields = FieldList::create(


### PR DESCRIPTION
As opening it in the same window - when going back, displays a broken page. 

Translates the button title.