### PR TITLE
BUGFIX: Fixed issue where the VirtualOwner would be set for every element on a page

### DIFF
--- a/src/Extension/BaseElementExtension.php
+++ b/src/Extension/BaseElementExtension.php
@@ -21,11 +21,6 @@ use SilverStripe\Versioned\Versioned;
 class BaseElementExtension extends DataExtension
 {
     /**
-     * @var mixed
-     */
-    protected $virtualOwner;
-
-    /**
      * @config
      *
      * @var boolean
@@ -60,7 +55,7 @@ class BaseElementExtension extends DataExtension
      */
     public function setVirtualOwner(ElementVirtual $owner)
     {
-        $this->virtualOwner = $owner;
+        $this->owner->setField('_virtualOwner', $owner);
         return $this;
     }
 
@@ -69,7 +64,7 @@ class BaseElementExtension extends DataExtension
      */
     public function getVirtualOwner()
     {
-        return $this->virtualOwner;
+        return $this->owner->getField('_virtualOwner');
     }
 
     /**
@@ -240,7 +235,7 @@ class BaseElementExtension extends DataExtension
 
         if ($page = $this->owner->getPage()) {
             $usage->push($page);
-            if ($this->virtualOwner) {
+            if ($this->owner->getField('_virtualOwner')) {
                 $page->setField('ElementType', 'Linked');
             } else {
                 $page->setField('ElementType', 'Master');


### PR DESCRIPTION
This pull request fixes an issue where the last virtual element on a page would cause all other elements on the page to have their VirtualOwner set to the last virtual element on the page. This is caused by extensions being singletons in Silverstripe 4. This pull request changes the `DNADesign\ElementalVirtual\Extensions\BaseElementExtension` class to use `$this->owner->setField()` and `$this->owner->getField()` to store the virtual owner rather than storing it as a protected variable on the extension.