### PR TITLE
ENH: set AvailableGlobally to false by default to match most likely u…

### DIFF
--- a/src/Extension/BaseElementExtension.php
+++ b/src/Extension/BaseElementExtension.php
@@ -35,7 +35,7 @@ class BaseElementExtension extends DataExtension
      * @var array
      */
     private static $db = [
-        'AvailableGlobally' => 'Boolean(1)',
+        'AvailableGlobally' => 'Boolean(0)',
         'VirtualLookupTitle' => 'Varchar(200)'
     ];
 


### PR DESCRIPTION
ENH: set AvailableGlobally to false by default to match most likely use case.

That is, most blocks will be unique on most pages, but some are "keepers" that you want to re-use.  To keep that list simple and manageable, we should set the default to "FALSE". 